### PR TITLE
Dev/fix tests

### DIFF
--- a/lib/formats/epub.rb
+++ b/lib/formats/epub.rb
@@ -533,7 +533,7 @@ class Peregrin::Epub
       File.open(working_dir("mimetype"), 'wb') { |f|
         f.write(MIMETYPE_MAP['.epub'])
       }
-      File.unlink(path)  if File.exists?(path)
+      File.unlink(path)  if File.exist?(path)
       cmd = [
         "cd #{working_dir}",
         "zip -0Xq ../#{filename} mimetype",

--- a/lib/formats/ochook.rb
+++ b/lib/formats/ochook.rb
@@ -8,13 +8,13 @@ class Peregrin::Ochook < Peregrin::Zhook
     unless File.directory?(path)
       raise DirectoryNotFound.new(path)
     end
-    unless File.exists?(File.join(path, INDEX_PATH))
+    unless File.exist?(File.join(path, INDEX_PATH))
       raise MissingIndexHTML.new(path)
     end
-    unless File.exists?(File.join(path, COVER_PATH))
+    unless File.exist?(File.join(path, COVER_PATH))
       raise MissingCoverPNG.new(path)
     end
-    unless File.exists?(File.join(path, MANIFEST_PATH))
+    unless File.exist?(File.join(path, MANIFEST_PATH))
       raise MissingManifest.new(path)
     end
 

--- a/lib/formats/zhook.rb
+++ b/lib/formats/zhook.rb
@@ -81,7 +81,7 @@ class Peregrin::Zhook
   # Writes the internal book object to a .zhook file at the given path.
   #
   def write(path)
-    File.unlink(path)  if File.exists?(path)
+    File.unlink(path)  if File.exist?(path)
     Zip::File.open(path, Zip::File::CREATE) { |zipfile|
       zipfile.get_output_stream(INDEX_PATH) { |f| f.write(htmlize(index)) }
       @book.resources.each { |resource|

--- a/lib/peregrin.rb
+++ b/lib/peregrin.rb
@@ -109,7 +109,7 @@ module Peregrin
       def self.format_for_path(path)
         return Peregrin::Zhook  if File.extname(path) == ".zhook"
         return Peregrin::Epub  if File.extname(path) == ".epub"
-        return Peregrin::Ochook  if File.directory?(path) || !File.exists?(path)
+        return Peregrin::Ochook  if File.directory?(path) || !File.exist?(path)
         raise UnknownFileFormat.new(path)
       end
 

--- a/lib/peregrin/componentizer.rb
+++ b/lib/peregrin/componentizer.rb
@@ -100,7 +100,7 @@ class Peregrin::Componentizer
             node['class'].match(/\barticle\b/)
           )
         )
-      end while node = node.next
+      end while node = node.next_element
       true
     end
 

--- a/test/formats/epub_test.rb
+++ b/test/formats/epub_test.rb
@@ -15,7 +15,7 @@ class Peregrin::Tests::EpubTest < Test::Unit::TestCase
   def test_write_to_epub
     epub = Peregrin::Epub.new(strunk_book)
     epub.write('test/output/strunk_test.epub')
-    assert(File.exists?('test/output/strunk_test.epub'))
+    assert(File.exist?('test/output/strunk_test.epub'))
     assert_nothing_raised {
       Peregrin::Epub.validate("test/output/strunk_test.epub")
     }
@@ -197,7 +197,7 @@ class Peregrin::Tests::EpubTest < Test::Unit::TestCase
   def test_read_epub_to_write_epub
     epub = Peregrin::Epub.read("test/fixtures/epubs/strunk.epub")
     epub.write("test/output/strunk_test2.epub")
-    assert(File.exists?('test/output/strunk_test2.epub'))
+    assert(File.exist?('test/output/strunk_test2.epub'))
     assert_nothing_raised {
       Peregrin::Epub.validate("test/output/strunk_test2.epub")
     }

--- a/test/utils/componentizer_test.rb
+++ b/test/utils/componentizer_test.rb
@@ -64,7 +64,7 @@ class Peregrin::Tests::ComponentizerTest < Test::Unit::TestCase
       whitewash(IO.read(tmp_path))
     )
   ensure
-    File.unlink(tmp_path)  if File.exists?(tmp_path)
+    File.unlink(tmp_path)  if File.exist?(tmp_path)
   end
 
 


### PR DESCRIPTION
Résolution de deux problèmes qui empêchaient les tests de tourner : 
- un avertissement "`File.exists?` is deprecated" (bon, ce warning pourrissait seulement la sortie, pas le résultat des tests),
- la gem qui n'extrayait pas correctement les données si le HTML était indenté (les nœuds texte vides étaient interprétés comme des morceaux de HTML).

Avant : 
![screenshot 2015-03-20 a 16 39 07](https://cloud.githubusercontent.com/assets/1035145/6755199/a662186c-cf21-11e4-82c9-eba55ed219e4.png)

Après : 
![screenshot 2015-03-20 a 16 38 38](https://cloud.githubusercontent.com/assets/1035145/6755263/0c7e3022-cf22-11e4-9102-89899f66e29a.png)
