### PR TITLE
Supprime le dossier de travail après epub.write

### DIFF
--- a/lib/formats/epub.rb
+++ b/lib/formats/epub.rb
@@ -362,7 +362,7 @@ class Peregrin::Epub
       FileUtils.mkdir_p(@working_dir)
       yield
     ensure
-      #FileUtils.rm_rf(@working_dir)
+      FileUtils.rm_rf(@working_dir) if File.exist?(@working_dir)
       @working_dir = nil
     end
 

--- a/lib/formats/epub.rb
+++ b/lib/formats/epub.rb
@@ -362,7 +362,7 @@ class Peregrin::Epub
       FileUtils.mkdir_p(@working_dir)
       yield
     ensure
-      FileUtils.rm_rf(@working_dir) if File.exist?(@working_dir)
+      FileUtils.rm_rf(@working_dir)
       @working_dir = nil
     end
 

--- a/test/formats/epub_test.rb
+++ b/test/formats/epub_test.rb
@@ -16,6 +16,7 @@ class Peregrin::Tests::EpubTest < Test::Unit::TestCase
     epub = Peregrin::Epub.new(strunk_book)
     epub.write('test/output/strunk_test.epub')
     assert(File.exist?('test/output/strunk_test.epub'))
+    assert(!File.exist?('test/output/strunk_test'), "Work directory has not been removed.")
     assert_nothing_raised {
       Peregrin::Epub.validate("test/output/strunk_test.epub")
     }


### PR DESCRIPTION
Il y avait un bug : après l'écriture du fichier de destination `la-duchesse-insoumise.epub`, il restait le dossier `la-duchesse-insoumise` contenant les fichiers de l'epub "dézippé".

La gem feedbooks se chargeait du rm_rf par après : pour moi, c'est au générateur d'epub de faire le ménage lui-même.
